### PR TITLE
Adds Dockerfile for kn container image

### DIFF
--- a/openshift/ci-operator/knative-images/client/Dockerfile
+++ b/openshift/ci-operator/knative-images/client/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+USER 65532
+
+ADD kn /ko-app/kn
+ENTRYPOINT ["/ko-app/kn"]


### PR DESCRIPTION
 Respective job for building this in CI needs to be setup after the
 Dockerfile is present in the branches (master and release-next).