### PR TITLE
Updates maintainer, version and entrypoint for kn Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rhel8/go-toolset:1.12.8 AS builder
+WORKDIR /opt/app-root/src/go/src/github.com/knative/client
+USER root
+COPY . .
+RUN TAG="v0.9.0" make build
+
+FROM ubi8:8-released
+COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn /ko-app/kn
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-tech-preview-client-kn-rhel8-container" \
+      name="openshift-serverless-1-tech-preview/client-kn-rhel8" \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 kn CLI" \
+      description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI" \
+      io.k8s.description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
+      io.openshift.build.source-location="https://github.com/openshift/knative-client" \
+      maintainer="serverless-support@redhat.com"
+
+ENTRYPOINT ["/ko-app/kn"]


### PR DESCRIPTION
 - OpenShift generally required the maintainer to be a mailing list. With this in mind, we can set it to serverless-support@redhat.com.
 - Updates the version to v0.9.0
 - Updates the entrypoint to /ko-app/kn to be consistent with other containers of the product and upstream kn container image