### PR TITLE
Place Dockerfile in release-next and release-vX branches

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -25,7 +25,7 @@ git checkout -b "$target" "$release"
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile Dockerfile
 #make RELEASE=$release generate-release
 #make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -26,7 +26,7 @@ git checkout upstream/master -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile Dockerfile container.yaml content_sets.yaml
 #make generate-dockerfiles
 #make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile


### PR DESCRIPTION
- Dockerfile placed at the root of the directory
- This ensures the Dockerfile is propagated per release branch as well as release-next branch
