### PR TITLE
Refer vendored deps while testing

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -159,7 +159,7 @@ function run_e2e_tests(){
   # Add local dir to have access to built kn
   export PATH=$PATH:${REPO_ROOT_DIR}
   export GO111MODULE=on
-  go_test_e2e -timeout=$E2E_TIMEOUT -parallel=$E2E_PARALLEL ./test/e2e || fail_test
+  go_test_e2e -timeout=$E2E_TIMEOUT -parallel=$E2E_PARALLEL -mod=vendor ./test/e2e || fail_test
   return $failed
 }
 


### PR DESCRIPTION
 - Add `-mod=vendor` flag while invoking e2e tests