### PR TITLE
Use hack/install.sh from serverless-operator repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rhel8/go-toolset:1.12.8 AS builder
+WORKDIR /opt/app-root/src/go/src/github.com/knative/client
+USER root
+COPY . .
+RUN TAG="v0.10.0" make build
+
+FROM ubi8:8-released
+COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn /ko-app/kn
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-tech-preview-client-kn-rhel8-container" \
+      name="openshift-serverless-1-tech-preview/client-kn-rhel8" \
+      version="0.10.0" \
+      summary="Red Hat OpenShift Serverless 1 kn CLI" \
+      description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI" \
+      io.k8s.description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
+      io.openshift.build.source-location="https://github.com/openshift/knative-client" \
+      maintainer="serverless-support@redhat.com"
+
+ENTRYPOINT ["/ko-app/kn"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+#This makefile is used by ci-operator
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CGO_ENABLED=0
+GOOS=linux
+
+install: build
+	cp ./kn $(GOPATH)/bin
+.PHONY: install
+
+build:
+	./hack/build.sh -f
+.PHONY: build
+
+build-cross:
+	./hack/build.sh -x
+.PHONY: build-cross
+
+test-unit:
+	./hack/build.sh -t
+.PHONY: test-unit
+
+test-e2e:
+	./openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Generates a ci-operator configuration for a specific branch.
+generate-ci-config:
+	./openshift/ci-operator/generate-ci-config.sh $(BRANCH) > ci-operator-config.yaml
+.PHONY: generate-ci-config

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
 approvers:
-- sixolet
-- cppforlife
-- rhuss
-- maximilien
-- navidshaikh
-# TOC members as a fallback
-- mattmoor
-- evankanderson
+- knative-client-approvers
+
+reviewers:
+- knative-client-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,17 @@
+aliases:
+  knative-client-approvers:
+  - alanfx
+  - bbrowning
+  - markusthoemmes
+  - vdemeester
+  - matzew
+  - rhuss
+  - navidshaikh
+  knative-client-reviewers:
+  - alanfx
+  - bbrowning
+  - markusthoemmes
+  - vdemeester
+  - matzew
+  - rhuss
+  - navidshaikh

--- a/container.yaml
+++ b/container.yaml
@@ -1,0 +1,8 @@
+---
+go:
+  modules:
+  - module: github.com/knative/client
+image_build_method: imagebuilder
+platforms:
+  only:
+  - x86_64

--- a/content_sets.yaml
+++ b/content_sets.yaml
@@ -1,0 +1,20 @@
+# This file is managed by the OpenShift Image Tool: https://github.com/openshift/enterprise-images,
+# by the OpenShift Continuous Delivery team (#aos-art on CoreOS Slack).
+# Any manual changes will be overwritten by OIT on the next build.
+#
+# This is a file defining which content sets (yum repositories) are needed to
+# update content in this image. Data provided here helps determine which images
+# are vulnerable to specific CVEs. Generally you should only need to update this
+# file when:
+#    1. You start depending on a new product
+#    2. You are preparing new product release and your content sets will change
+#
+# See https://mojo.redhat.com/docs/DOC-1023066 for more information on
+# maintaining this file and the format and examples
+#
+# You should have one top level item for each architecture being built. Most
+# likely this will be x86_64 and ppc64le initially.
+---
+x86_64:
+- rhel-8-for-x86_64-baseos-rpms
+- rhel-8-for-x86_64-appstream-rpms

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile to bootstrap build and test in openshift-ci
+FROM openshift/origin-release:golang-1.12
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+branch=${1-'master'}
+
+cat <<EOF
+tag_specification:
+  name: '4.1'
+  namespace: ocp
+promotion:
+  cluster: https://api.ci.openshift.org
+  namespace: openshift
+  name: $branch
+base_images:
+  base:
+    name: '4.0'
+    namespace: ocp
+    tag: base
+build_root:
+  project_image:
+    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
+canonical_go_repository: github.com/knative/client
+binary_build_commands: make build
+tests:
+- as: e2e
+  commands: "make test-e2e"
+  openshift_installer_src:
+    cluster_profile: aws
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+EOF

--- a/openshift/ci-operator/knative-images/client/Dockerfile
+++ b/openshift/ci-operator/knative-images/client/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+USER 65532
+
+ADD kn /ko-app/kn
+ENTRYPOINT ["/ko-app/kn"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+
+set -x
+
+readonly KN_DEFAULT_TEST_IMAGE="gcr.io/knative-samples/helloworld-go"
+readonly SERVING_NAMESPACE="knative-serving"
+readonly SERVICEMESH_NAMESPACE="knative-serving-ingress"
+readonly E2E_TIMEOUT="60m"
+readonly E2E_PARALLEL="1"
+readonly OLM_NAMESPACE="openshift-marketplace"
+env
+
+function scale_up_workers(){
+  local cluster_api_ns="openshift-machine-api"
+
+  oc get machineset -n ${cluster_api_ns} --show-labels
+
+  # Get the name of the first machineset that has at least 1 replica
+  local machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
+  oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6
+}
+
+# Waits until the machineset in the given namespaces scales up to the
+# desired number of replicas
+# Parameters: $1 - namespace
+#             $2 - machineset name
+#             $3 - desired number of replicas
+function wait_until_machineset_scales_up() {
+  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
+  for i in {1..150}; do  # timeout after 15 minutes
+    local available=$(oc get machineset -n $1 $2 -o jsonpath="{.status.availableReplicas}")
+    if [[ ${available} -eq $3 ]]; then
+      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo - "\n\nError: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  return 1
+}
+
+# Waits until the given hostname resolves via DNS
+# Parameters: $1 - hostname
+function wait_until_hostname_resolves() {
+  echo -n "Waiting until hostname $1 resolves via DNS"
+  for i in {1..150}; do  # timeout after 15 minutes
+    local output="$(host -t a $1 | grep 'has address')"
+    if [[ -n "${output}" ]]; then
+      echo -e "\n${output}"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\nERROR: timeout waiting for hostname $1 to resolve via DNS"
+  return 1
+}
+
+# Loops until duration (car) is exceeded or command (cdr) returns non-zero
+function timeout() {
+  SECONDS=0; TIMEOUT=$1; shift
+  while eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && return 1
+  done
+  return 0
+}
+
+function install_knative_serving(){
+  header "Installing Knative serving"
+
+  oc new-project $SERVING_NAMESPACE
+
+  # Deploy Serverless Operator
+  deploy_serverless_operator
+
+  # Install Knative Serving
+  cat <<-EOF | oc apply -f -
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: ${SERVING_NAMESPACE}
+EOF
+
+  # Wait for 4 pods to appear first
+  timeout 900 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return
+
+  wait_until_pods_running $SERVING_NAMESPACE || return 1
+
+  wait_until_service_has_external_ip $SERVICEMESH_NAMESPACE istio-ingressgateway || fail_test "Ingress has no external IP"
+
+  wait_until_hostname_resolves "$(kubectl get svc -n $SERVICEMESH_NAMESPACE istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+
+  header "Knative Serving installed successfully"
+}
+
+function deploy_serverless_operator(){
+  git clone https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator
+  /tmp/serverless-operator/hack/catalog.sh | oc apply -n $OLM_NAMESPACE -f -
+
+  timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || ret
+
+  wait_until_pods_running $OLM_NAMESPACE
+
+  cat <<-EOF | kubectl apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator-sub
+  generateName: serverless-operator-
+  namespace: openshift-operators
+spec:
+  source: serverless-operator
+  sourceNamespace: $OLM_NAMESPACE
+  name: serverless-operator
+  channel: techpreview
+EOF
+
+  # Wait for the CRD to appear
+  timeout 900 '[[ $(oc get crd | grep -c knativeservings) -eq 0 ]]' || return 1
+}
+
+function build_knative_client() {
+  failed=0
+  # run this cross platform build to ensure all the checks pass (as this is done while building artifacts)
+  ./hack/build.sh -x || failed=1
+
+  if [[ $failed -eq 0 ]]; then
+    mv kn-linux-amd64 kn
+  fi
+
+  return $failed
+}
+
+function run_e2e_tests(){
+  header "Running e2e tests"
+  failed=0
+  # Add local dir to have access to built kn
+  export PATH=$PATH:${REPO_ROOT_DIR}
+  export GO111MODULE=on
+  go_test_e2e -timeout=$E2E_TIMEOUT -parallel=$E2E_PARALLEL -mod=vendor ./test/e2e || fail_test
+  return $failed
+}
+
+# Waits until all pods are running in the given namespace.
+# Parameters: $1 - namespace.
+function wait_until_pods_running() {
+  echo -n "Waiting until all pods in namespace $1 are up"
+  for i in {1..150}; do  # timeout after 5 minutes
+    local pods="$(kubectl get pods --no-headers -n $1 2>/dev/null)"
+    # All pods must be running
+    local not_running=$(echo "${pods}" | grep -v Running | grep -v Completed | wc -l)
+    if [[ -n "${pods}" && ${not_running} -eq 0 ]]; then
+      local all_ready=1
+      while read pod ; do
+        local status=(`echo -n ${pod} | cut -f2 -d' ' | tr '/' ' '`)
+        # All containers must be ready
+        [[ -z ${status[0]} ]] && all_ready=0 && break
+        [[ -z ${status[1]} ]] && all_ready=0 && break
+        [[ ${status[0]} -lt 1 ]] && all_ready=0 && break
+        [[ ${status[1]} -lt 1 ]] && all_ready=0 && break
+        [[ ${status[0]} -ne ${status[1]} ]] && all_ready=0 && break
+      done <<< "$(echo "${pods}" | grep -v Completed)"
+      if (( all_ready )); then
+        echo -e "\nAll pods are up:\n${pods}"
+        return 0
+      fi
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for pods to come up\n${pods}"
+  return 1
+}
+
+function delete_knative_openshift() {
+  echo ">> Bringing down Knative Serving"
+  oc delete --ignore-not-found=true -f openshift/serverless/operator-install.yaml
+  oc delete --ignore-not-found=true project $SERVING_NAMESPACE
+}
+
+function delete_test_namespace(){
+  echo ">> Deleting test namespaces"
+  oc delete project --ignore-not-found=true kne2etests0 kne2etests1 kne2etests2 kne2etests3 kne2etests4 kne2etests5
+}
+
+
+echo ">> Check resources"
+echo ">> - meminfo:"
+cat /proc/meminfo
+echo ">> - memory.limit_in_bytes"
+cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+echo ">> - cpu.cfs_period_us"
+cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+echo ">> - cpu.cfs_quota_us"
+cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+
+scale_up_workers || exit 1
+
+failed=0
+
+(( !failed )) && build_knative_client || failed=1
+
+(( !failed )) && install_knative_serving || failed=1
+
+(( !failed )) && run_e2e_tests || failed=1
+
+(( failed )) && exit 1
+
+success

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -86,59 +86,11 @@ function timeout() {
   return 0
 }
 
-function install_knative_serving(){
-  header "Installing Knative serving"
-
-  oc new-project $SERVING_NAMESPACE
-
-  # Deploy Serverless Operator
-  deploy_serverless_operator
-
-  # Install Knative Serving
-  cat <<-EOF | oc apply -f -
-apiVersion: serving.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: ${SERVING_NAMESPACE}
-EOF
-
-  # Wait for 4 pods to appear first
-  timeout 900 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return
-
-  wait_until_pods_running $SERVING_NAMESPACE || return 1
-
-  wait_until_service_has_external_ip $SERVICEMESH_NAMESPACE istio-ingressgateway || fail_test "Ingress has no external IP"
-
-  wait_until_hostname_resolves "$(kubectl get svc -n $SERVICEMESH_NAMESPACE istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
-
-  header "Knative Serving installed successfully"
-}
-
-function deploy_serverless_operator(){
+function install_serverless_operator(){
+  header "Installing Serverless Operator"
   git clone https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator
-  /tmp/serverless-operator/hack/catalog.sh | oc apply -n $OLM_NAMESPACE -f -
-
-  timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || ret
-
-  wait_until_pods_running $OLM_NAMESPACE
-
-  cat <<-EOF | kubectl apply -f -
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: serverless-operator-sub
-  generateName: serverless-operator-
-  namespace: openshift-operators
-spec:
-  source: serverless-operator
-  sourceNamespace: $OLM_NAMESPACE
-  name: serverless-operator
-  channel: techpreview
-EOF
-
-  # Wait for the CRD to appear
-  timeout 900 '[[ $(oc get crd | grep -c knativeservings) -eq 0 ]]' || return 1
+  /tmp/serverless-operator/hack/install.sh || return 1
+  header "Serverless Operator installed successfully"
 }
 
 function build_knative_client() {
@@ -222,7 +174,7 @@ failed=0
 
 (( !failed )) && build_knative_client || failed=1
 
-(( !failed )) && install_knative_serving || failed=1
+(( !failed )) && install_serverless_operator || failed=1
 
 (( !failed )) && run_e2e_tests || failed=1
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -89,6 +89,9 @@ function timeout() {
 function install_serverless_operator(){
   header "Installing Serverless Operator"
   git clone https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator
+  # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
+  # to use CI built images, we want pre-built images of k-s-o and k-o-i
+  unset OPENSHIFT_BUILD_NAMESPACE
   /tmp/serverless-operator/hack/install.sh || return 1
   header "Serverless Operator installed successfully"
 }

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -1,0 +1,35 @@
+# Release creation
+
+## Branching
+
+As far as branching goes, we have two use-cases:
+
+1. Creating a branch based off an upstream release tag.
+2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
+
+A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
+that points to the upstream repository and a remote "openshift" that points to the openshift fork.
+
+Run the scripts from the root of the repository.
+
+### Creating a branch based off an upstream release tag
+
+To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
+
+```bash
+$ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
+```
+
+This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
+files that we need to run CI on top of it.
+
+### Updating the release-next branch that follow upstream's HEAD
+
+To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
+
+```bash
+$ ./openshift/release/update-to-head.sh
+```
+
+That will pull the latest master from upstream, rebase the current fixes on the release-next branch
+on top of it, update the Openshift specific files if necessary, and then trigger CI.

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: create-release-branch.sh v0.4.1 release-0.4
+
+release=$1
+target=$2
+
+# Fetch the latest tags and checkout a new branch from the wanted tag.
+git fetch upstream --tags
+git checkout -b "$target" "$release"
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile Dockerfile
+#make RELEASE=$release generate-release
+#make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m "Add openshift specific files."

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
+
+set -e
+REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+
+# Reset release-next to upstream/master.
+git fetch upstream master
+git checkout upstream/master -B release-next
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile Dockerfile container.yaml content_sets.yaml
+#make generate-dockerfiles
+#make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m ":open_file_folder: Update openshift specific files."
+
+git push -f openshift release-next
+
+# Trigger CI
+git checkout release-next -B release-next-ci
+date > ci
+git add ci
+git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/master"
+git push -f openshift release-next-ci
+
+if hash hub 2>/dev/null; then
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+else
+   echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
+fi

--- a/openshift/serverless/operator-install.yaml
+++ b/openshift/serverless/operator-install.yaml
@@ -1,0 +1,34 @@
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operators.coreos.com/v1
+kind: CatalogSourceConfig
+metadata:
+  name: ci-serverless-operator
+  namespace: openshift-marketplace
+spec:
+  targetNamespace: openshift-operators
+  packages: serverless-operator
+  source: redhat-operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-operators
+spec:
+  channel: techpreview
+  name: serverless-operator
+  source: ci-serverless-operator
+  sourceNamespace: openshift-operators


### PR DESCRIPTION
 - To configure serverless-operator, knative-serving and dependencies.
 - Unset `OPENSHIFT_BUILD_NAMESPACE` env var as its used by serverless-operator in its own CI to use the CI built images for k-s-o and k-o-i, client uses pre-built images

/hold

