### PR TITLE
Carry container.yaml and content_sets.yaml for release-branch

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -25,8 +25,6 @@ git checkout -b "$target" "$release"
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile Dockerfile
-#make RELEASE=$release generate-release
-#make RELEASE=ci generate-release
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile Dockerfile container.yaml content_sets.yaml
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."


### PR DESCRIPTION
 - As part of stacking 'OpenShift specific files' on top of upstream release branch
 - These couple of files are needed for building kn container at brew