### PR TITLE
Update Dockerfile for release v0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM rhel8/go-toolset:1.12.8 AS builder
+FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/client
 USER root
 COPY . .
-RUN TAG="v0.10.0" make build
+RUN TAG="v0.11.0" make build
 
 FROM ubi8:8-released
 COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn /ko-app/kn
@@ -10,7 +10,7 @@ COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn /ko-ap
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-client-kn-rhel8-container" \
       name="openshift-serverless-1-tech-preview/client-kn-rhel8" \
-      version="0.10.0" \
+      version="v0.11.0" \
       summary="Red Hat OpenShift Serverless 1 kn CLI" \
       description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI" \


### PR DESCRIPTION
 - Update Dockerfile to use rhel8/go-toolset:1.13.4 builder image
 - Update 'version' label in Dockerfile as 'v0.11.0' (earlier it was without 'v')
 - Defines TAG var in Makefile, which will be set for a released version of kn for e.g. 'v0.11.0' for release-tagged kn image at quay