### PR TITLE
Add KN_OPENSHIFT_CI env var for e2e tests

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -179,6 +179,7 @@ function run_e2e_tests(){
   # while invoking go e2e tests. Unsetting to keep using -mod=vendor irrespective of whether GOFLAGS is set or not.
   # Ideally this should be overridden but see https://github.com/golang/go/issues/35827
   unset GOFLAGS
+  export KN_OPENSHIFT_CI=1
   go_test_e2e -timeout=$E2E_TIMEOUT -mod=vendor ./test/e2e || fail_test
   return $failed
 }


### PR DESCRIPTION
 This is needed for using namespace annotated artibtrary user id
 range for `--user` flag in e2e tests for OpenShift.
 Any random user id wont work as security context does not allow that.