### PR TITLE
Install python2 in cli-artifacts container for kn download server

### DIFF
--- a/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+++ b/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install -y zip tar gzip
+RUN microdnf install -y zip tar gzip python2
 ADD package_cliartifacts.sh LICENSE kn-*-amd64* .
 RUN bash package_cliartifacts.sh && \
     mkdir -p /usr/share/kn/linux_amd64 && \


### PR DESCRIPTION
 Install python2 in base image so we could run simple
 kn download server using python2 script