### PR TITLE
Zero delta between midstream and downstream

### DIFF
--- a/openshift-serverless-clients.spec
+++ b/openshift-serverless-clients.spec
@@ -6,8 +6,8 @@
 %global kn_version 0.13.1
 %global kn_release 1
 %global kn_cli_version v%{kn_version}
-%global source_dir knative-client-%{kn_version}-%{kn_release}
-%global source_tar %{source_dir}.tar.gz
+%global source_dir knative-client
+%global source_tar %{source_dir}-%{kn_version}-%{kn_release}.tar.gz
 
 Name:           %{package_name}
 Version:        %{kn_version}

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -30,6 +30,7 @@ Dockerfile.cliartifacts.rhel
 package_cliartifacts.sh
 container.yaml
 content_sets.yaml
+openshift-serverless-clients.spec
 EOT
 )
 

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -20,15 +20,28 @@
 set -e
 REPO_NAME=`basename $(git rev-parse --show-toplevel)`
 
+# Custom files
+custom_files=$(cat <<EOT | tr '\n' ' '
+openshift
+OWNERS_ALIASES
+OWNERS
+Makefile
+Dockerfile.rhel
+Dockerfile.cliartifacts.rhel
+package_cliartifacts.sh
+container.yaml
+content_sets.yaml
+openshift-serverless-clients.spec
+EOT
+)
+
 # Reset release-next to upstream/master.
 git fetch upstream master
 git checkout upstream/master -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile Dockerfile.rhel Dockerfile.cliartifacts.rhel package_cliartifacts.sh container.yaml content_sets.yaml
-#make generate-dockerfiles
-#make RELEASE=ci generate-release
+git checkout openshift/master $custom_files
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m ":open_file_folder: Update openshift specific files."
 


### PR DESCRIPTION
-  RPM SPEC file is now propogated in release-* branches
     This is to ensure zero delta between midstream and downstream.
     Also syncing release-next branch for nightly downstream OR test building RPM in CI (TODO).

- Update SPEC file, versioned tar file name, unversioned dir name
     This should simplify performing tar operation after sync from midstream and doing build.

FYI: @warrenvw 
