### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile.cliartifacts.rhel
+++ b/Dockerfile.cliartifacts.rhel
@@ -1,22 +1,25 @@
-FROM rhel8/go-toolset:1.13.4 AS builder
+FROM ubi8-minimal:8-released AS packager
 WORKDIR /opt/app-root/src/go/src/github.com/knative/client
-USER root
-COPY . .
-RUN TAG="v0.12.0" make build-cross-package
+# add signed cross platform binaries from lookaside cache
+ADD kn-linux-amd64 kn-darwin-amd64 kn-windows-amd64.exe .
+COPY package_cliartifacts.sh LICENSE .
+RUN microdnf install -y zip tar gzip && \
+    bash package_cliartifacts.sh
 
-FROM ubi8:8-released
-RUN mkdir -p /usr/share/kn/{linux_amd64,macos,windows}
-COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/kn-linux-amd64.tar.gz
-COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn-macos-amd64.tar.gz /usr/share/kn/macos/kn-macos-amd64.tar.gz
-COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn-windows-amd64.zip /usr/share/kn/windows/kn-windows-amd64.zip
+FROM ubi8-minimal:8-released
+RUN microdnf install -y python2 && \
+  mkdir -p /usr/share/kn/{linux_amd64,macos,windows}
+COPY --from=packager /opt/app-root/src/go/src/github.com/knative/client/kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/
+COPY --from=packager /opt/app-root/src/go/src/github.com/knative/client/kn-macos-amd64.tar.gz /usr/share/kn/macos/
+COPY --from=packager /opt/app-root/src/go/src/github.com/knative/client/kn-windows-amd64.zip  /usr/share/kn/windows/
 
 LABEL \
-      com.redhat.component="openshift-serverless-1-client-kn-rhel8-container" \
-      name="openshift-serverless-1/client-kn-rhel8" \
-      version="v0.12.0" \
-      summary="Red Hat OpenShift Serverless 1 kn CLI" \
-      description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI" \
-      io.k8s.description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
+      com.redhat.component="openshift-serverless-1-client-kn-cli-artifacts-rhel8-container" \
+      name="openshift-serverless-1/client-kn-cli-artifacts-rhel8" \
+      version="v0.13.2" \
+      summary="Red Hat OpenShift Serverless 1 kn CLI artifacts image" \
+      description="Image of 'kn' CLI cross platform binaries for managing Red Hat OpenShift Serverless 1" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI artifacts image" \
+      io.k8s.description="Image of 'kn' CLI cross platform binaries for managing Red Hat OpenShift Serverless 1" \
       io.openshift.build.source-location="https://github.com/openshift/knative-client" \
       maintainer="serverless-support@redhat.com"

--- a/Dockerfile.cliartifacts.rhel
+++ b/Dockerfile.cliartifacts.rhel
@@ -17,9 +17,9 @@ LABEL \
       com.redhat.component="openshift-serverless-1-client-kn-cli-artifacts-rhel8-container" \
       name="openshift-serverless-1/client-kn-cli-artifacts-rhel8" \
       version="v0.13.2" \
-      summary="Red Hat OpenShift Serverless 1 kn CLI artifacts image" \
-      description="Image of 'kn' CLI cross platform binaries for managing Red Hat OpenShift Serverless 1" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI artifacts image" \
-      io.k8s.description="Image of 'kn' CLI cross platform binaries for managing Red Hat OpenShift Serverless 1" \
+      summary="Red Hat OpenShift Serverless 1 kn CLI artifacts" \
+      description="'kn' CLI cross platform binaries for managing Red Hat OpenShift Serverless 1" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI artifacts" \
+      io.k8s.description="'kn' CLI cross platform binaries for managing Red Hat OpenShift Serverless 1" \
       io.openshift.build.source-location="https://github.com/openshift/knative-client" \
       maintainer="serverless-support@redhat.com"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -2,15 +2,15 @@ FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/client
 USER root
 COPY . .
-RUN TAG="v0.13.0" make build
+RUN TAG="v0.13.2" make build
 
-FROM ubi8:8-released
+FROM ubi8-minimal:8-released
 COPY --from=builder /opt/app-root/src/go/src/github.com/knative/client/kn /ko-app/kn
 
 LABEL \
       com.redhat.component="openshift-serverless-1-client-kn-rhel8-container" \
       name="openshift-serverless-1/client-kn-rhel8" \
-      version="0.13.0" \
+      version="0.13.2" \
       summary="Red Hat OpenShift Serverless 1 kn CLI" \
       description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI" \

--- a/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+++ b/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
@@ -1,10 +1,11 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /opt/app-root/src/go/src/github.com/knative/client
 RUN microdnf install -y zip tar gzip python2
-ADD package_cliartifacts.sh LICENSE kn-*-amd64* serve.py .
+ADD package_cliartifacts.sh LICENSE kn-*-amd64* serve.py ./
 RUN bash package_cliartifacts.sh && \
     mkdir -p /usr/share/kn/{linux_amd64,macos,windows} && \
     mv kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/ && \
     mv kn-macos-amd64.tar.gz /usr/share/kn/macos/ && \
     mv kn-windows-amd64.zip /usr/share/kn/windows/
-ENTRYPOINT ["python2 serve.py"]
+ENTRYPOINT ["/usr/bin/python2"]
+CMD ["serve.py"]

--- a/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+++ b/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
@@ -1,22 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
+WORKDIR /opt/app-root/src/go/src/github.com/knative/client
 RUN microdnf install -y zip tar gzip python2
-ADD package_cliartifacts.sh LICENSE kn-*-amd64* .
+ADD package_cliartifacts.sh LICENSE kn-*-amd64* serve.py .
 RUN bash package_cliartifacts.sh && \
-    mkdir -p /usr/share/kn/linux_amd64 && \
-    mkdir -p /usr/share/kn/macos && \
-    mkdir -p /usr/share/kn/windows && \
+    mkdir -p /usr/share/kn/{linux_amd64,macos,windows} && \
     mv kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/ && \
     mv kn-macos-amd64.tar.gz /usr/share/kn/macos/ && \
     mv kn-windows-amd64.zip /usr/share/kn/windows/
-
-LABEL \
-      com.redhat.component="openshift-serverless-1-tech-preview-client-kn-rhel8-container" \
-      name="openshift-serverless-1-tech-preview/client-kn-rhel8" \
-      version="v0.13.0" \
-      summary="Red Hat OpenShift Serverless 1 kn CLI" \
-      description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 kn CLI" \
-      io.k8s.description="CLI client 'kn' for managing Red Hat OpenShift Serverless 1" \
-      io.openshift.build.source-location="https://github.com/openshift/knative-client" \
-      maintainer="serverless-support@redhat.com"
+ENTRYPOINT ["python2 serve.py"]

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,52 @@
+import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
+
+signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
+
+# Launch multiple listeners as threads
+class Thread(threading.Thread):
+    def __init__(self, i, socket):
+        threading.Thread.__init__(self)
+        self.i = i
+        self.socket = socket
+        self.daemon = True
+        self.start()
+
+    def run(self):
+        httpd = BaseHTTPServer.HTTPServer(addr, SimpleHTTPServer.SimpleHTTPRequestHandler, False)
+
+        # Prevent the HTTP server from re-binding every handler.
+        # https://stackoverflow.com/questions/46210672/
+        httpd.socket = self.socket
+        httpd.server_bind = self.server_close = lambda self: None
+
+        httpd.serve_forever()
+
+temp_dir = tempfile.mkdtemp()
+print('serving from {}'.format(temp_dir))
+os.chdir(temp_dir)
+for arch in ['amd64']:
+    os.mkdir(arch)
+    for operating_system in ['linux', 'macos', 'windows']:
+        os.mkdir(os.path.join(arch, operating_system))
+
+for arch, operating_system, path in [
+        ('amd64', 'linux', '/usr/share/kn/linux_amd64/kn-linux-amd64.tar.gz'),
+        ('amd64', 'macos', '/usr/share/kn/macos/kn-macos-amd64.tar.gz'),
+        ('amd64', 'windows', '/usr/share/kn/windows/kn-windows-amd64.zip'),
+        ]:
+    basename = os.path.basename(path)
+    target_path = os.path.join(arch, operating_system, basename)
+    os.symlink(path, target_path)
+
+# Create socket
+# IPv6 should handle IPv4 passively so long as it is not bound to a
+# specific address or set to IPv6_ONLY
+# https://stackoverflow.com/questions/25817848/python-3-does-http-server-support-ipv6
+addr = ('::', 8080)
+sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(addr)
+sock.listen(5)
+
+[Thread(i, socket=sock) for i in range(100)]
+time.sleep(9e9)

--- a/serve.py
+++ b/serve.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python2
+
 import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
 
 signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))


### PR DESCRIPTION
- Building RHEL kn-cli-artifacts image with signed binaries from lookaside cache
- New base image
- Updated labels
- Improved layering in images
- New Python script for serving kn cli artifacts
- kn-cli-artifacts image entry point now set to Python script serving artifacts
- Updated kn version tag to 0.13.2