### PR TITLE
Checkout serve.py for release-next and release branches

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -31,6 +31,7 @@ package_cliartifacts.sh
 container.yaml
 content_sets.yaml
 openshift-serverless-clients.spec
+serve.py
 EOT
 )
 

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -32,6 +32,7 @@ package_cliartifacts.sh
 container.yaml
 content_sets.yaml
 openshift-serverless-clients.spec
+serve.py
 EOT
 )
 


### PR DESCRIPTION
  Its needed for the image builds.