### PR TITLE
Fix WORKDIR issue for OCP 3.11

### DIFF
--- a/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+++ b/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
@@ -1,4 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# we'd need to create WORKDIR before hand to workaround image builder issue
+# on OCP 3.11 where it requires it present before referencing
+RUN mkdir -p /opt/app-root/src/go/src/github.com/knative/client
 WORKDIR /opt/app-root/src/go/src/github.com/knative/client
 RUN microdnf install -y zip tar gzip python2
 ADD package_cliartifacts.sh LICENSE kn-*-amd64* serve.py ./


### PR DESCRIPTION
 images job might run on OCP 3.11 (api.ci) and we'd need to create
 dir before referncing it via WORKDIR. (issue with imagebuilder on OCP 3.11)