### PR TITLE
Configure eventing, serving separately and run tests separately

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -21,13 +21,14 @@ set -x
 
 readonly KN_DEFAULT_TEST_IMAGE="gcr.io/knative-samples/helloworld-go"
 readonly SERVING_NAMESPACE="knative-serving"
-readonly SERVICEMESH_NAMESPACE="knative-serving-ingress"
+readonly EVENTING_NAMESPACE="knative-eventing"
 readonly E2E_TIMEOUT="60m"
 readonly OLM_NAMESPACE="openshift-marketplace"
+readonly EVENTING_CATALOGSOURCE="https://raw.githubusercontent.com/openshift/knative-eventing/master/openshift/olm/knative-eventing.catalogsource.yaml"
 env
 
 # Loops until duration (car) is exceeded or command (cdr) returns non-zero
-function timeout() {
+function timeout_non_zero() {
   SECONDS=0; TIMEOUT=$1; shift
   while eval $*; do
     sleep 5
@@ -42,7 +43,8 @@ function scale_up_workers(){
   oc get machineset -n ${cluster_api_ns} --show-labels
 
   # Get the name of the first machineset that has at least 1 replica
-  local machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  local machineset
+  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
   # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
   oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
   wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6
@@ -95,6 +97,13 @@ function install_serverless(){
   header "Serverless Operator installed successfully"
 }
 
+function teardown_serverless(){
+  header "Tear down Serverless Operator"
+  /tmp/serverless-operator/hack/teardown.sh || return 1
+  header "Serverless Operator uninstalled successfully"
+}
+
+
 function deploy_knative_operator(){
   local COMPONENT="knative-$1"
   local API_GROUP=$1
@@ -125,7 +134,7 @@ function deploy_knative_operator(){
 
   # # Wait until the server knows about the Install CRD before creating
   # # an instance of it below
-  timeout 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
+  timeout_non_zero 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
 }
 
 function build_knative_client() {
@@ -141,6 +150,7 @@ function build_knative_client() {
 }
 
 function run_e2e_tests(){
+  TAGS=$1
   header "Running e2e tests"
   failed=0
   # Add local dir to have access to built kn
@@ -154,7 +164,11 @@ function run_e2e_tests(){
   # Add anyuid scc to all authenticated users so e2e tests for --user flag can user any user id
   oc adm policy add-scc-to-group anyuid system:authenticated
 
-  go_test_e2e -timeout=$E2E_TIMEOUT -mod=vendor ./test/e2e || fail_test
+  go test \
+    ./test/e2e \
+    -v -timeout=$E2E_TIMEOUT -mod=vendor \
+    -tags="e2e $TAGS" || fail_test
+
   return $failed
 }
 
@@ -189,6 +203,87 @@ function wait_until_pods_running() {
   return 1
 }
 
+function install_serverless_1_6(){
+  header "Installing Serverless Operator"
+  git clone --branch release-1.6 https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator-16
+  # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
+  # to use CI built images, we want pre-built images of k-s-o and k-o-i
+  unset OPENSHIFT_BUILD_NAMESPACE
+  /tmp/serverless-operator-16/hack/install.sh || return 1
+  header "Serverless Operator installed successfully"
+}
+
+function create_knative_namespace(){
+  local COMPONENT="knative-$1"
+
+  cat <<-EOF | oc apply -f -
+	apiVersion: v1
+	kind: Namespace
+	metadata:
+	  name: ${COMPONENT}
+	EOF
+}
+
+function deploy_knative_operator(){
+  local COMPONENT="knative-$1"
+  local API_GROUP=$1
+  local KIND=$2
+
+  cat <<-EOF | oc apply -f -
+	apiVersion: v1
+	kind: Namespace
+	metadata:
+	  name: ${COMPONENT}
+	EOF
+  if oc get crd operatorgroups.operators.coreos.com >/dev/null 2>&1; then
+    cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1
+	kind: OperatorGroup
+	metadata:
+	  name: ${COMPONENT}
+	  namespace: ${COMPONENT}
+	EOF
+  fi
+  cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1alpha1
+	kind: Subscription
+	metadata:
+	  name: ${COMPONENT}-subscription
+	  generateName: ${COMPONENT}-
+	  namespace: ${COMPONENT}
+	spec:
+	  source: ${COMPONENT}-operator
+	  sourceNamespace: $OLM_NAMESPACE
+	  name: ${COMPONENT}-operator
+	  channel: alpha
+	EOF
+
+  # # Wait until the server knows about the Install CRD before creating
+  # # an instance of it below
+  timeout_non_zero 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
+}
+
+function install_knative_eventing(){
+  header "Installing Knative Eventing"
+
+  create_knative_namespace eventing
+
+  # oc apply -n $OLM_NAMESPACE -f knative-eventing.catalogsource-ci.yaml
+  oc apply -n $OLM_NAMESPACE -f $EVENTING_CATALOGSOURCE
+  timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
+  wait_until_pods_running $OLM_NAMESPACE
+
+  # Deploy Knative Operators Eventing
+  deploy_knative_operator eventing KnativeEventing
+
+  # Wait for 5 pods to appear first
+  timeout_non_zero 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
+  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+
+  # Assert that there are no images used that are not CI images (which should all be using the $INTERNAL_REGISTRY)
+  # (except for the knative-eventing-operator)
+  #oc get pod -n knative-eventing -o yaml | grep image: | grep -v knative-eventing-operator | grep -v ${INTERNAL_REGISTRY} && return 1 || true
+}
 
 echo ">> Check resources"
 echo ">> - meminfo:"
@@ -208,7 +303,15 @@ failed=0
 
 (( !failed )) && install_serverless || failed=1
 
-(( !failed )) && run_e2e_tests || failed=1
+(( !failed )) && run_e2e_tests serving || failed=1
+
+(( !failed )) && teardown_serverless || failed=1
+
+(( !failed )) && install_serverless_1_6 || failed=1
+
+(( !failed )) && install_knative_eventing || failed=1
+
+(( !failed )) && run_e2e_tests eventing || failed=1
 
 (( failed )) && exit 1
 


### PR DESCRIPTION
 - First run serving e2e specific tests
 - teardown
 - Setup eventing nightly and run eventing e2e specific tests