### PR TITLE
Update path for importing test infra scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+#This makefile is used by ci-operator
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CGO_ENABLED=0
+GOOS=linux
+
+install: build
+	cp ./kn $(GOPATH)/bin
+.PHONY: install
+
+build:
+	./hack/build.sh -f
+.PHONY: build
+
+build-cross:
+	./hack/build.sh -x
+.PHONY: build-cross
+
+build-cross-package: build-cross
+	./package_cliartifacts.sh
+.PHONY: build-cross-package
+
+test-unit:
+	./hack/build.sh -t
+.PHONY: test-unit
+
+test-e2e:
+	./openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Generates a ci-operator configuration for a specific branch.
+generate-ci-config:
+	./openshift/ci-operator/generate-ci-config.sh $(BRANCH) > ci-operator-config.yaml
+.PHONY: generate-ci-config

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
 approvers:
-- sixolet
-- cppforlife
-- rhuss
-- maximilien
-- navidshaikh
-# TOC members as a fallback
-- mattmoor
-- evankanderson
+- knative-client-approvers
+
+reviewers:
+- knative-client-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+aliases:
+  knative-client-approvers:
+  - alanfx
+  - markusthoemmes
+  - matzew
+  - rhuss
+  - navidshaikh
+  knative-client-reviewers:
+  - alanfx
+  - markusthoemmes
+  - matzew
+  - rhuss
+  - navidshaikh

--- a/openshift-serverless-clients.spec
+++ b/openshift-serverless-clients.spec
@@ -1,0 +1,99 @@
+#debuginfo not supported with Go
+%global debug_package %{nil}
+%global package_name openshift-serverless-clients
+%global product_name OpenShift Serverless
+%global golang_version 1.13
+%global kn_version 0.13.2
+%global kn_release 1
+%global kn_cli_version v%{kn_version}
+%global source_dir knative-client
+%global source_tar %{source_dir}-%{kn_version}-%{kn_release}.tar.gz
+
+Name:           %{package_name}
+Version:        %{kn_version}
+Release:        %{kn_release}%{?dist}
+Summary:        %{product_name} client kn CLI binary
+License:        ASL 2.0
+URL:            https://github.com/openshift/knative-client/tree/release-%{kn_cli_version}
+
+ExclusiveArch:  x86_64
+
+Source0:        %{source_tar}
+BuildRequires:  golang >= %{golang_version}
+Provides:       %{package_name}
+Obsoletes:      %{package_name} < %{kn_version}
+
+%description
+Client kn provides developer experience to work with Knative Serving APIs.
+
+%prep
+%setup -q -n %{source_dir}
+
+%build
+TAG=%{kn_cli_version} make build-cross
+
+%install
+mkdir -p %{buildroot}/%{_bindir}
+install -m 0755 kn-linux-amd64 %{buildroot}/%{_bindir}/kn
+
+install -d %{buildroot}%{_datadir}/%{name}-redistributable/{linux,macos,windows}
+install -p -m 755 kn-linux-amd64 %{buildroot}%{_datadir}/%{name}-redistributable/linux/kn-linux-amd64
+install -p -m 755 kn-darwin-amd64 %{buildroot}/%{_datadir}/%{name}-redistributable/macos/kn-darwin-amd64
+install -p -m 755 kn-windows-amd64.exe %{buildroot}/%{_datadir}/%{name}-redistributable/windows/kn-windows-amd64.exe
+
+%files
+%license LICENSE
+%{_bindir}/kn
+
+%package redistributable
+Summary:        %{product_name} client CLI binaries for Linux, macOS and Windows
+BuildRequires:  golang >= %{golang_version}
+Provides:       %{package_name}-redistributable
+Obsoletes:      %{package_name} < %{kn_version}
+
+%description redistributable
+%{product_name} client kn cross platform binaries for Linux, macOS and Windows.
+
+%files redistributable
+%license LICENSE
+%dir %{_datadir}/%{name}-redistributable/linux/
+%dir %{_datadir}/%{name}-redistributable/macos/
+%dir %{_datadir}/%{name}-redistributable/windows/
+%{_datadir}/%{name}-redistributable/linux/kn-linux-amd64
+%{_datadir}/%{name}-redistributable/macos/kn-darwin-amd64
+%{_datadir}/%{name}-redistributable/windows/kn-windows-amd64.exe
+
+%changelog
+* Thu Apr 16 2020 Navid Shaikh <nshaikh@redhat.com> v0.13.2-1
+- Bump kn release v0.13.2
+
+* Mon Mar 09 2020 Navid Shaikh <nshaikh@redhat.com> v0.13.1-1
+- Bump kn release v0.13.1
+
+* Mon Mar 09 2020 Navid Shaikh <nshaikh@redhat.com> v0.12.0-1
+- Bump kn release v0.12.0
+
+* Wed Jan 22 2020 Navid Shaikh <nshaikh@redhat.com> v0.11.0-1
+- Bump kn release v0.11.0
+
+* Fri Dec 13 2019 Navid Shaikh <nshaikh@redhat.com> v0.10.0-1
+- Bump kn release v0.10.0
+
+* Fri Nov 08 2019 Navid Shaikh <nshaikh@redhat.com> v0.9.0-1
+- Bump kn release v0.9.0
+
+* Wed Aug 28 2019 Navid Shaikh <nshaikh@redhat.com> v0.2.3-1
+- First tech preview release
+- Uses dist macro to include the target platform in RPM name
+
+* Mon Aug 26 2019 Navid Shaikh <nshaikh@redhat.com> v0.2.2-2
+- Initial tech preview release
+- Uses license abbrevation ASL 2.0 for Apache Software License 2.0
+- bump the release to v0.2.2-2
+
+* Mon Aug 26 2019 Navid Shaikh <nshaikh@redhat.com> v0.2.2-1
+- Initial tech preview release
+- bump the version to v0.2.2
+
+* Tue Aug 20 2019 Navid Shaikh <nshaikh@redhat.com> v0.2.1-1
+- Initial tech preview release

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile to bootstrap build and test in openshift-ci
+FROM openshift/origin-release:golang-1.13
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+branch=${1-'master'}
+
+cat <<EOF
+tag_specification:
+  name: '4.1'
+  namespace: ocp
+promotion:
+  cluster: https://api.ci.openshift.org
+  namespace: openshift
+  name: $branch
+base_images:
+  base:
+    name: '4.0'
+    namespace: ocp
+    tag: base
+build_root:
+  project_image:
+    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
+canonical_go_repository: github.com/knative/client
+binary_build_commands: make build
+tests:
+- as: e2e
+  commands: "make test-e2e"
+  openshift_installer_src:
+    cluster_profile: aws
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+EOF

--- a/openshift/ci-operator/knative-images/client/Dockerfile
+++ b/openshift/ci-operator/knative-images/client/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+USER 65532
+
+ADD kn /ko-app/kn
+ENTRYPOINT ["/ko-app/kn"]

--- a/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+++ b/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# we'd need to create WORKDIR before hand to workaround image builder issue
+# on OCP 3.11 where it requires it present before referencing
+RUN mkdir -p /opt/app-root/src/go/src/github.com/knative/client
+WORKDIR /opt/app-root/src/go/src/github.com/knative/client
+RUN microdnf install -y zip tar gzip python2
+ADD package_cliartifacts.sh LICENSE kn-*-amd64* serve.py ./
+RUN bash package_cliartifacts.sh && \
+    mkdir -p /usr/share/kn/{linux_amd64,macos,windows} && \
+    mv kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/ && \
+    mv kn-macos-amd64.tar.gz /usr/share/kn/macos/ && \
+    mv kn-windows-amd64.zip /usr/share/kn/windows/
+CMD ["python3", "serve.py"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
-source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/scripts/test-infra/library.sh
+source ${ROOT_DIR}/scripts/test-infra/e2e-tests.sh
 
 set -x
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+
+set -x
+
+readonly KN_DEFAULT_TEST_IMAGE="gcr.io/knative-samples/helloworld-go"
+readonly SERVING_NAMESPACE="knative-serving"
+readonly EVENTING_NAMESPACE="knative-eventing"
+readonly E2E_TIMEOUT="60m"
+readonly OLM_NAMESPACE="openshift-marketplace"
+readonly EVENTING_CATALOGSOURCE="https://raw.githubusercontent.com/openshift/knative-eventing/master/openshift/olm/knative-eventing.catalogsource.yaml"
+env
+
+# Loops until duration (car) is exceeded or command (cdr) returns non-zero
+function timeout_non_zero() {
+  SECONDS=0; TIMEOUT=$1; shift
+  while eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && return 1
+  done
+  return 0
+}
+
+function scale_up_workers(){
+  local cluster_api_ns="openshift-machine-api"
+
+  oc get machineset -n ${cluster_api_ns} --show-labels
+
+  # Get the name of the first machineset that has at least 1 replica
+  local machineset
+  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
+  oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6
+}
+
+# Waits until the machineset in the given namespaces scales up to the
+# desired number of replicas
+# Parameters: $1 - namespace
+#             $2 - machineset name
+#             $3 - desired number of replicas
+function wait_until_machineset_scales_up() {
+  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
+  for i in {1..150}; do  # timeout after 15 minutes
+    local available=$(oc get machineset -n $1 $2 -o jsonpath="{.status.availableReplicas}")
+    if [[ ${available} -eq $3 ]]; then
+      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo - "\n\nError: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  return 1
+}
+
+# Waits until the given hostname resolves via DNS
+# Parameters: $1 - hostname
+function wait_until_hostname_resolves() {
+  echo -n "Waiting until hostname $1 resolves via DNS"
+  for i in {1..150}; do  # timeout after 15 minutes
+    local output="$(host -t a $1 | grep 'has address')"
+    if [[ -n "${output}" ]]; then
+      echo -e "\n${output}"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\nERROR: timeout waiting for hostname $1 to resolve via DNS"
+  return 1
+}
+
+function install_serverless(){
+  header "Installing Serverless Operator"
+  git clone https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator
+  # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
+  # to use CI built images, we want pre-built images of k-s-o and k-o-i
+  unset OPENSHIFT_BUILD_NAMESPACE
+  /tmp/serverless-operator/hack/install.sh || return 1
+  header "Serverless Operator installed successfully"
+}
+
+function teardown_serverless(){
+  header "Tear down Serverless Operator"
+  /tmp/serverless-operator/hack/teardown.sh || return 1
+  header "Serverless Operator uninstalled successfully"
+}
+
+
+function deploy_knative_operator(){
+  local COMPONENT="knative-$1"
+  local API_GROUP=$1
+  local KIND=$2
+
+  if oc get crd operatorgroups.operators.coreos.com >/dev/null 2>&1; then
+    cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1
+	kind: OperatorGroup
+	metadata:
+	  name: ${COMPONENT}
+	  namespace: ${COMPONENT}
+	EOF
+  fi
+  cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1alpha1
+	kind: Subscription
+	metadata:
+	  name: ${COMPONENT}-subscription
+	  generateName: ${COMPONENT}-
+	  namespace: ${COMPONENT}
+	spec:
+	  source: ${COMPONENT}-operator
+	  sourceNamespace: $OLM_NAMESPACE
+	  name: ${COMPONENT}-operator
+	  channel: alpha
+	EOF
+
+  # # Wait until the server knows about the Install CRD before creating
+  # # an instance of it below
+  timeout_non_zero 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
+}
+
+function build_knative_client() {
+  failed=0
+  # run this cross platform build to ensure all the checks pass (as this is done while building artifacts)
+  ./hack/build.sh -x || failed=1
+
+  if [[ $failed -eq 0 ]]; then
+    mv kn-linux-amd64 kn
+  fi
+
+  return $failed
+}
+
+function run_e2e_tests(){
+  TAGS=$1
+  header "Running e2e tests"
+  failed=0
+  # Add local dir to have access to built kn
+  export PATH=$PATH:${REPO_ROOT_DIR}
+  export GO111MODULE=on
+  # In CI environment GOFLAGS is set to '-mod=vendor', unsetting it and providing explicit flag below
+  # while invoking go e2e tests. Unsetting to keep using -mod=vendor irrespective of whether GOFLAGS is set or not.
+  # Ideally this should be overridden but see https://github.com/golang/go/issues/35827
+  unset GOFLAGS
+
+  # Add anyuid scc to all authenticated users so e2e tests for --user flag can user any user id
+  oc adm policy add-scc-to-group anyuid system:authenticated
+
+  go test \
+    ./test/e2e \
+    -v -timeout=$E2E_TIMEOUT -mod=vendor \
+    -tags="e2e $TAGS" || fail_test
+
+  return $failed
+}
+
+# Waits until all pods are running in the given namespace.
+# Parameters: $1 - namespace.
+function wait_until_pods_running() {
+  echo -n "Waiting until all pods in namespace $1 are up"
+  for i in {1..150}; do  # timeout after 5 minutes
+    local pods="$(kubectl get pods --no-headers -n $1 2>/dev/null)"
+    # All pods must be running
+    local not_running=$(echo "${pods}" | grep -v Running | grep -v Completed | wc -l)
+    if [[ -n "${pods}" && ${not_running} -eq 0 ]]; then
+      local all_ready=1
+      while read pod ; do
+        local status=(`echo -n ${pod} | cut -f2 -d' ' | tr '/' ' '`)
+        # All containers must be ready
+        [[ -z ${status[0]} ]] && all_ready=0 && break
+        [[ -z ${status[1]} ]] && all_ready=0 && break
+        [[ ${status[0]} -lt 1 ]] && all_ready=0 && break
+        [[ ${status[1]} -lt 1 ]] && all_ready=0 && break
+        [[ ${status[0]} -ne ${status[1]} ]] && all_ready=0 && break
+      done <<< "$(echo "${pods}" | grep -v Completed)"
+      if (( all_ready )); then
+        echo -e "\nAll pods are up:\n${pods}"
+        return 0
+      fi
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for pods to come up\n${pods}"
+  return 1
+}
+
+function install_serverless_1_6(){
+  header "Installing Serverless Operator"
+  git clone --branch release-1.6 https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator-16
+  # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
+  # to use CI built images, we want pre-built images of k-s-o and k-o-i
+  unset OPENSHIFT_BUILD_NAMESPACE
+  /tmp/serverless-operator-16/hack/install.sh || return 1
+  header "Serverless Operator installed successfully"
+}
+
+function create_knative_namespace(){
+  local COMPONENT="knative-$1"
+
+  cat <<-EOF | oc apply -f -
+	apiVersion: v1
+	kind: Namespace
+	metadata:
+	  name: ${COMPONENT}
+	EOF
+}
+
+function deploy_knative_operator(){
+  local COMPONENT="knative-$1"
+  local API_GROUP=$1
+  local KIND=$2
+
+  cat <<-EOF | oc apply -f -
+	apiVersion: v1
+	kind: Namespace
+	metadata:
+	  name: ${COMPONENT}
+	EOF
+  if oc get crd operatorgroups.operators.coreos.com >/dev/null 2>&1; then
+    cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1
+	kind: OperatorGroup
+	metadata:
+	  name: ${COMPONENT}
+	  namespace: ${COMPONENT}
+	EOF
+  fi
+  cat <<-EOF | oc apply -f -
+	apiVersion: operators.coreos.com/v1alpha1
+	kind: Subscription
+	metadata:
+	  name: ${COMPONENT}-subscription
+	  generateName: ${COMPONENT}-
+	  namespace: ${COMPONENT}
+	spec:
+	  source: ${COMPONENT}-operator
+	  sourceNamespace: $OLM_NAMESPACE
+	  name: ${COMPONENT}-operator
+	  channel: alpha
+	EOF
+
+  # # Wait until the server knows about the Install CRD before creating
+  # # an instance of it below
+  timeout_non_zero 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
+}
+
+function install_knative_eventing(){
+  header "Installing Knative Eventing"
+
+  create_knative_namespace eventing
+
+  # oc apply -n $OLM_NAMESPACE -f knative-eventing.catalogsource-ci.yaml
+  oc apply -n $OLM_NAMESPACE -f $EVENTING_CATALOGSOURCE
+  timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
+  wait_until_pods_running $OLM_NAMESPACE
+
+  # Deploy Knative Operators Eventing
+  deploy_knative_operator eventing KnativeEventing
+
+  # Wait for 5 pods to appear first
+  timeout_non_zero 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
+  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+
+  # Assert that there are no images used that are not CI images (which should all be using the $INTERNAL_REGISTRY)
+  # (except for the knative-eventing-operator)
+  #oc get pod -n knative-eventing -o yaml | grep image: | grep -v knative-eventing-operator | grep -v ${INTERNAL_REGISTRY} && return 1 || true
+}
+
+echo ">> Check resources"
+echo ">> - meminfo:"
+cat /proc/meminfo
+echo ">> - memory.limit_in_bytes"
+cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+echo ">> - cpu.cfs_period_us"
+cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+echo ">> - cpu.cfs_quota_us"
+cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+
+scale_up_workers || exit 1
+
+failed=0
+
+(( !failed )) && build_knative_client || failed=1
+
+(( !failed )) && install_serverless || failed=1
+
+(( !failed )) && run_e2e_tests serving || failed=1
+
+(( !failed )) && teardown_serverless || failed=1
+
+(( !failed )) && install_serverless_1_6 || failed=1
+
+(( !failed )) && install_knative_eventing || failed=1
+
+(( !failed )) && run_e2e_tests eventing || failed=1
+
+(( failed )) && exit 1
+
+success

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -1,0 +1,35 @@
+# Release creation
+
+## Branching
+
+As far as branching goes, we have two use-cases:
+
+1. Creating a branch based off an upstream release tag.
+2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
+
+A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
+that points to the upstream repository and a remote "openshift" that points to the openshift fork.
+
+Run the scripts from the root of the repository.
+
+### Creating a branch based off an upstream release tag
+
+To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
+
+```bash
+$ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
+```
+
+This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
+files that we need to run CI on top of it.
+
+### Updating the release-next branch that follow upstream's HEAD
+
+To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
+
+```bash
+$ ./openshift/release/update-to-head.sh
+```
+
+That will pull the latest master from upstream, rebase the current fixes on the release-next branch
+on top of it, update the Openshift specific files if necessary, and then trigger CI.

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: create-release-branch.sh v0.4.1 release-0.4
+
+release=$1
+target=$2
+
+# Custom files
+custom_files=$(cat <<EOT | tr '\n' ' '
+openshift
+OWNERS_ALIASES
+OWNERS
+Makefile
+package_cliartifacts.sh
+openshift-serverless-clients.spec
+serve.py
+EOT
+)
+
+
+# Fetch the latest tags and checkout a new branch from the wanted tag.
+git fetch upstream --tags
+git checkout -b "$target" "$release"
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master $custom_files
+git add $custom_files
+git commit -m "Add openshift specific files."

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
+
+set -e
+REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+
+# Custom files
+custom_files=$(cat <<EOT | tr '\n' ' '
+openshift
+OWNERS_ALIASES
+OWNERS
+Makefile
+package_cliartifacts.sh
+openshift-serverless-clients.spec
+serve.py
+EOT
+)
+
+# Reset release-next to upstream/master.
+git fetch upstream master
+git checkout upstream/master -B release-next
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master $custom_files
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m ":open_file_folder: Update openshift specific files."
+
+git push -f openshift release-next
+
+# Trigger CI
+git checkout release-next -B release-next-ci
+date > ci
+git add ci
+git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/master"
+git push -f openshift release-next-ci
+
+if hash hub 2>/dev/null; then
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+else
+   echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
+fi

--- a/openshift/serverless/operator-install.yaml
+++ b/openshift/serverless/operator-install.yaml
@@ -1,0 +1,34 @@
+# Copyright 2019 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operators.coreos.com/v1
+kind: CatalogSourceConfig
+metadata:
+  name: ci-serverless-operator
+  namespace: openshift-marketplace
+spec:
+  targetNamespace: openshift-operators
+  packages: serverless-operator
+  source: redhat-operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-operators
+spec:
+  channel: techpreview
+  name: serverless-operator
+  source: ci-serverless-operator
+  sourceNamespace: openshift-operators

--- a/package_cliartifacts.sh
+++ b/package_cliartifacts.sh
@@ -1,0 +1,49 @@
+# This script is used to package kn cross platform cli artifacts
+# for kn-cli-artifacts image
+# Copyright 2020 The OpenShift Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pkg_tar() {
+  local dir
+  case "$1" in
+    x86_64)
+		  dir=linux
+    	mkdir "${OUTDIR}/${dir}"
+    	mv kn-linux-amd64 ${OUTDIR}/${dir}/kn
+      ;;
+    macos)
+		  dir=macos
+    	mkdir "${OUTDIR}/${dir}"
+    	mv kn-darwin-amd64 ${OUTDIR}/${dir}/kn
+      ;;
+      #uncomment following when we support building mentioned archs
+      #aarch64|ppc64le|s390x) dir=linux-${1};;
+  esac
+  cp LICENSE ${OUTDIR}/${dir}
+  tar -zcf kn-${dir}-amd64.tar.gz -C ${OUTDIR}/${dir} .
+}
+
+pkg_zip_for_windows() {
+  mkdir "${OUTDIR}/windows"
+	mv kn-windows-amd64.exe ${OUTDIR}/windows/kn.exe
+	cp LICENSE ${OUTDIR}/windows/
+	zip --quiet --junk-path - ${OUTDIR}/windows/* > kn-windows-amd64.zip
+}
+
+OUTDIR=$(mktemp -dt knbinary.XXXXXXXXXX)
+trap "rm -rf '${OUTDIR}'" EXIT INT TERM
+
+pkg_tar x86_64
+pkg_tar macos
+pkg_zip_for_windows

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+
+import http.server, os, re, signal, http.server, socket, sys, tarfile, tempfile, threading, time, zipfile
+
+signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
+
+# Launch multiple listeners as threads
+class Thread(threading.Thread):
+    def __init__(self, i, socket):
+        threading.Thread.__init__(self)
+        self.i = i
+        self.socket = socket
+        self.daemon = True
+        self.start()
+
+    def run(self):
+        httpd = http.server.HTTPServer(addr, http.server.SimpleHTTPRequestHandler, False)
+
+        # Prevent the HTTP server from re-binding every handler.
+        # https://stackoverflow.com/questions/46210672/
+        httpd.socket = self.socket
+        httpd.server_bind = self.server_close = lambda self: None
+
+        httpd.serve_forever()
+
+temp_dir = tempfile.mkdtemp()
+print(('serving from {}'.format(temp_dir)))
+os.chdir(temp_dir)
+for arch in ['amd64']:
+    os.mkdir(arch)
+    for operating_system in ['linux', 'macos', 'windows']:
+        os.mkdir(os.path.join(arch, operating_system))
+
+for arch, operating_system, path in [
+        ('amd64', 'linux', '/usr/share/kn/linux_amd64/kn-linux-amd64.tar.gz'),
+        ('amd64', 'macos', '/usr/share/kn/macos/kn-macos-amd64.tar.gz'),
+        ('amd64', 'windows', '/usr/share/kn/windows/kn-windows-amd64.zip'),
+        ]:
+    basename = os.path.basename(path)
+    target_path = os.path.join(arch, operating_system, basename)
+    os.symlink(path, target_path)
+
+# Create socket
+# IPv6 should handle IPv4 passively so long as it is not bound to a
+# specific address or set to IPv6_ONLY
+# https://stackoverflow.com/questions/25817848/python-3-does-http-server-support-ipv6
+addr = ('::', 8080)
+sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(addr)
+sock.listen(5)
+
+[Thread(i, socket=sock) for i in range(100)]
+time.sleep(9e9)


### PR DESCRIPTION
 as the test-infra scripts are no longer under vendor dir but at the root of repo

/hold 
