### PR TITLE
Clean up e2e test script

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -26,10 +26,12 @@ readonly EVENTING_NAMESPACE="knative-eventing"
 readonly E2E_TIMEOUT="60m"
 readonly OLM_NAMESPACE="openshift-marketplace"
 readonly EVENTING_CATALOGSOURCE="https://raw.githubusercontent.com/openshift/knative-eventing/master/openshift/olm/knative-eventing.catalogsource.yaml"
+readonly OPERATOR_CLONE_PATH="/tmp/serverless-operator"
+
 env
 
 # Loops until duration (car) is exceeded or command (cdr) returns non-zero
-function timeout_non_zero() {
+function timeout() {
   SECONDS=0; TIMEOUT=$1; shift
   while eval $*; do
     sleep 5
@@ -38,69 +40,19 @@ function timeout_non_zero() {
   return 0
 }
 
-function scale_up_workers(){
-  local cluster_api_ns="openshift-machine-api"
-
-  oc get machineset -n ${cluster_api_ns} --show-labels
-
-  # Get the name of the first machineset that has at least 1 replica
-  local machineset
-  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
-  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
-  oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
-  wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6
-}
-
-# Waits until the machineset in the given namespaces scales up to the
-# desired number of replicas
-# Parameters: $1 - namespace
-#             $2 - machineset name
-#             $3 - desired number of replicas
-function wait_until_machineset_scales_up() {
-  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
-  for i in {1..150}; do  # timeout after 15 minutes
-    local available=$(oc get machineset -n $1 $2 -o jsonpath="{.status.availableReplicas}")
-    if [[ ${available} -eq $3 ]]; then
-      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
-      return 0
-    fi
-    echo -n "."
-    sleep 6
-  done
-  echo - "\n\nError: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
-  return 1
-}
-
-# Waits until the given hostname resolves via DNS
-# Parameters: $1 - hostname
-function wait_until_hostname_resolves() {
-  echo -n "Waiting until hostname $1 resolves via DNS"
-  for i in {1..150}; do  # timeout after 15 minutes
-    local output="$(host -t a $1 | grep 'has address')"
-    if [[ -n "${output}" ]]; then
-      echo -e "\n${output}"
-      return 0
-    fi
-    echo -n "."
-    sleep 6
-  done
-  echo -e "\n\nERROR: timeout waiting for hostname $1 to resolve via DNS"
-  return 1
-}
-
 function install_serverless(){
   header "Installing Serverless Operator"
-  git clone https://github.com/openshift-knative/serverless-operator.git /tmp/serverless-operator
+  git clone https://github.com/openshift-knative/serverless-operator.git ${OPERATOR_CLONE_PATH} || return 1
   # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
   # to use CI built images, we want pre-built images of k-s-o and k-o-i
   unset OPENSHIFT_BUILD_NAMESPACE
-  /tmp/serverless-operator/hack/install.sh || return 1
+  ${OPERATOR_CLONE_PATH}/hack/install.sh || return 1
   header "Serverless Operator installed successfully"
 }
 
 function teardown_serverless(){
   header "Tear down Serverless Operator"
-  /tmp/serverless-operator/hack/teardown.sh || return 1
+  ${OPERATOR_CLONE_PATH}/hack/teardown.sh || return 1
   header "Serverless Operator uninstalled successfully"
 }
 
@@ -135,7 +87,7 @@ function deploy_knative_operator(){
 
   # # Wait until the server knows about the Install CRD before creating
   # # an instance of it below
-  timeout_non_zero 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
+  timeout 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
 }
 
 function build_knative_client() {
@@ -261,7 +213,7 @@ function deploy_knative_operator(){
 
   # # Wait until the server knows about the Install CRD before creating
   # # an instance of it below
-  timeout_non_zero 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
+  timeout 60 '[[ $(oc get crd knative${API_GROUP}s.${API_GROUP}.knative.dev -o jsonpath="{.status.acceptedNames.kind}" | grep -c $KIND) -eq 0 ]]' || return 1
 }
 
 function install_knative_eventing(){
@@ -271,14 +223,14 @@ function install_knative_eventing(){
 
   # oc apply -n $OLM_NAMESPACE -f knative-eventing.catalogsource-ci.yaml
   oc apply -n $OLM_NAMESPACE -f $EVENTING_CATALOGSOURCE
-  timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
+  timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE
 
   # Deploy Knative Operators Eventing
   deploy_knative_operator eventing KnativeEventing
 
   # Wait for 5 pods to appear first
-  timeout_non_zero 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
+  timeout 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 1
 
   # Assert that there are no images used that are not CI images (which should all be using the $INTERNAL_REGISTRY)
@@ -295,8 +247,6 @@ echo ">> - cpu.cfs_period_us"
 cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
 echo ">> - cpu.cfs_quota_us"
 cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
-
-scale_up_workers || exit 1
 
 failed=0
 


### PR DESCRIPTION
 - Remove scale up cluster step as its done via operator install.sh
 - Define the operator clone path and error if cloning fails
 - Build client as first step before scaling cluster/installing operator