### PR TITLE
Use python3 and http.server

### DIFF
--- a/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
+++ b/openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
@@ -1,9 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install -y zip tar gzip python2
+RUN microdnf install -y zip tar gzip python3
 ADD package_cliartifacts.sh LICENSE kn-*-amd64* serve.py ./
 RUN bash package_cliartifacts.sh && \
     mkdir -p /usr/share/kn/{linux_amd64,macos,windows} && \
     mv kn-linux-amd64.tar.gz /usr/share/kn/linux_amd64/ && \
     mv kn-macos-amd64.tar.gz /usr/share/kn/macos/ && \
     mv kn-windows-amd64.zip /usr/share/kn/windows/
-CMD ["python2", "serve.py"]
+CMD ["python3", "serve.py"]

--- a/serve.py
+++ b/serve.py
@@ -1,6 +1,6 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
-import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
+import http.server, os, re, signal, http.server, socket, sys, tarfile, tempfile, threading, time, zipfile
 
 signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
@@ -14,7 +14,7 @@ class Thread(threading.Thread):
         self.start()
 
     def run(self):
-        httpd = BaseHTTPServer.HTTPServer(addr, SimpleHTTPServer.SimpleHTTPRequestHandler, False)
+        httpd = http.server.HTTPServer(addr, http.server.SimpleHTTPRequestHandler, False)
 
         # Prevent the HTTP server from re-binding every handler.
         # https://stackoverflow.com/questions/46210672/
@@ -24,7 +24,7 @@ class Thread(threading.Thread):
         httpd.serve_forever()
 
 temp_dir = tempfile.mkdtemp()
-print('serving from {}'.format(temp_dir))
+print(('serving from {}'.format(temp_dir)))
 os.chdir(temp_dir)
 for arch in ['amd64']:
     os.mkdir(arch)


### PR DESCRIPTION
The kn-cli-downloads pod fails with this error:

```
Traceback (most recent call last):
  File "serve.py", line 3, in <module>
    import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
ModuleNotFoundError: No module named 'BaseHTTPServer' 
```

This PR addresses the above error.