### PR TITLE
chore: Add test image build Dockerfile & build cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 
 CGO_ENABLED=0
 GOOS=linux
+TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d)
+KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 
 install: build
 	cp ./kn $(GOPATH)/bin
@@ -32,6 +34,10 @@ build-cross:
 build-cross-package: build-cross
 	./package_cliartifacts.sh
 .PHONY: build-cross-package
+
+test-install:
+    go install $(TEST_IMAGES)
+.PHONY: test-install
 
 test-unit:
 	./hack/build.sh -t

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,0 +1,4 @@
+FROM openshift/origin-base
+
+ADD helloworld /usr/bin/helloworld
+ENTRYPOINT ["/usr/bin/helloworld"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -27,6 +27,8 @@ readonly EVENTING_NAMESPACE="knative-eventing"
 readonly E2E_TIMEOUT="60m"
 readonly OLM_NAMESPACE="openshift-marketplace"
 
+readonly TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-client-test-{{.Name}}}"
+
 # if you want to setup the nightly serving/eventing, set `release-next` below or else set release branch
 readonly SERVING_BRANCH="release-next"
 readonly EVENTING_BRANCH="release-next"
@@ -91,6 +93,7 @@ run_e2e_tests(){
   go test \
     ./test/e2e \
     -v -timeout=$E2E_TIMEOUT -mod=vendor \
+    --imagetemplate $TEST_IMAGE_TEMPLATE \
     -tags="e2e $TAGS" || fail_test
 
   return $failed


### PR DESCRIPTION
Add artefacts to build test image `helloworld`.

@navidshaikh I'm not quiet sure if `KO_DOCKER_REPO` is needed. How will e2e tests pick up the correct image url?

Line 20:
```
KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
```