### PR TITLE
fix: Resolve symlink in test image look-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d)
+TEST_IMAGES=$(shell find -L ./test/test_images -mindepth 1 -maxdepth 1 -type d)
 KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 
 install: build


### PR DESCRIPTION
It's needed to find grpc-ping image path also.

/assign @navidshaikh 

