### PR TITLE
chore: Update generate-ci-config.sh template to be usable again

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -14,7 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-branch=${1-'master'}
+if [ -n "$1" ]; then
+  # Use provided branch value
+  branch=$1
+else
+  # Use current branch otherwise
+  branch=$(git rev-parse --abbrev-ref HEAD)
+fi
 version=$(echo ${branch} | cut -d '-' -f 2)
 tag=${version:-'master'}
 
@@ -76,7 +82,16 @@ tag_specification:
 test_binary_build_commands: make test-install
 tests:
 - as: e2e-aws-ocp-45
-  commands: make test-e2e
-  openshift_installer_src:
+  steps:
     cluster_profile: aws
+    test:
+    - as: test
+      cli: latest
+      commands: make test-e2e
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    workflow: ipi-aws
 EOF


### PR DESCRIPTION
A little life improvement to release process, generated CI config can be copied to appropriate openshift/release dir. We should probably keep the template up-to-date. :smile_cat: 

<details>
<summary>Generated file preview</summary>

```bash
➜  client git:(openshift-master) ✗ make BRANCH=release-v0.17.2 generate-ci-config
./openshift/ci-operator/generate-ci-config.sh release-v0.17.2 > ci-operator-config.yaml
➜  client git:(openshift-master) ✗ cat ci-operator-config.yaml 
base_images:
  base:
    name: ubi-minimal
    namespace: ocp
    tag: "8"
binary_build_commands: |
  TAG=v0.17.2 make install
  TAG=v0.17.2 make build-cross
build_root:
  project_image:
    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
canonical_go_repository: github.com/knative/client
images:
- dockerfile_path: openshift/ci-operator/knative-images/client/Dockerfile
  from: base
  inputs:
    bin:
      paths:
      - destination_dir: .
        source_path: /go/bin/kn
  to: knative-client
- dockerfile_path: openshift/ci-operator/knative-images/client/Dockerfile.cliartifacts
  inputs:
    bin:
      paths:
      - destination_dir: .
        source_path: /go/src/github.com/knative/client/kn-linux-amd64
      - destination_dir: .
        source_path: /go/src/github.com/knative/client/kn-darwin-amd64
      - destination_dir: .
        source_path: /go/src/github.com/knative/client/kn-windows-amd64.exe
      - destination_dir: .
        source_path: /go/src/github.com/knative/client/LICENSE
      - destination_dir: .
        source_path: /go/src/github.com/knative/client/package_cliartifacts.sh
  to: kn-cli-artifacts
- dockerfile_path: openshift/ci-operator/knative-test-images/helloworld/Dockerfile
  from: base
  inputs:
    test-bin:
      paths:
      - destination_dir: .
        source_path: /go/bin/helloworld
  to: knative-client-test-helloworld
promotion:
  name: release-v0.17.2
  namespace: openshift
resources:
  '*':
    requests:
      memory: 2Gi
tag_specification:
  name: "4.5"
  namespace: ocp
test_binary_build_commands: make test-install
tests:
- as: e2e-aws-ocp-45
  commands: make test-e2e
  openshift_installer_src:
    cluster_profile: aws
```
</details>