### PR TITLE
Make kn binary executable which goes inside tar file

### DIFF
--- a/package_cliartifacts.sh
+++ b/package_cliartifacts.sh
@@ -20,12 +20,14 @@ pkg_tar() {
     x86_64)
 		  dir=linux
     	mkdir "${OUTDIR}/${dir}"
-    	mv kn-linux-amd64 ${OUTDIR}/${dir}/kn
+      mv kn-linux-amd64 ${OUTDIR}/${dir}/kn
+      chmod u+x ${OUTDIR}/${dir}/kn
       ;;
     macos)
 		  dir=macos
     	mkdir "${OUTDIR}/${dir}"
     	mv kn-darwin-amd64 ${OUTDIR}/${dir}/kn
+      chmod u+x ${OUTDIR}/${dir}/kn
       ;;
       #uncomment following when we support building mentioned archs
       #aarch64|ppc64le|s390x) dir=linux-${1};;

--- a/package_cliartifacts.sh
+++ b/package_cliartifacts.sh
@@ -21,13 +21,13 @@ pkg_tar() {
 		  dir=linux
     	mkdir "${OUTDIR}/${dir}"
       mv kn-linux-amd64 ${OUTDIR}/${dir}/kn
-      chmod u+x ${OUTDIR}/${dir}/kn
+      chmod +x ${OUTDIR}/${dir}/kn
       ;;
     macos)
 		  dir=macos
     	mkdir "${OUTDIR}/${dir}"
     	mv kn-darwin-amd64 ${OUTDIR}/${dir}/kn
-      chmod u+x ${OUTDIR}/${dir}/kn
+      chmod +x ${OUTDIR}/${dir}/kn
       ;;
       #uncomment following when we support building mentioned archs
       #aarch64|ppc64le|s390x) dir=linux-${1};;


### PR DESCRIPTION
  When user extracts the kn tar.gz file, she should get the
  the executable kn binary.