### PR TITLE
Update kn-plugin-source-kafka to v0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/code-generator v0.18.8
 	knative.dev/eventing v0.18.5-0.20201105155307-650096a39064
-	knative.dev/kn-plugin-source-kafka v0.0.0-20201203183209-e1f755efaca3
+	knative.dev/kn-plugin-source-kafka v0.18.0
 	knative.dev/networking v0.0.0-20200922180040-a71b40c69b15
 	knative.dev/pkg v0.0.0-20201026165741-2f75016c1368
 	knative.dev/serving v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -1910,8 +1910,8 @@ knative.dev/eventing-contrib v0.11.2/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J
 knative.dev/eventing-contrib v0.18.6 h1:6xEzPkbKbY3Iq9LPKNNjLcYiadOXZGw/eVYAdDuIAF4=
 knative.dev/eventing-contrib v0.18.6/go.mod h1:Y3pKSlnqk5pG8r/2wljnPiZa1NPu/qjdQ3bX8ex2WVw=
 knative.dev/hack v0.0.0-20201120192952-353db687ec5b/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/kn-plugin-source-kafka v0.0.0-20201203183209-e1f755efaca3 h1:tBvI18pFlqv5jlXRsQQFoNhCfnuojioNhhX61bn4PAc=
-knative.dev/kn-plugin-source-kafka v0.0.0-20201203183209-e1f755efaca3/go.mod h1:1ERx7q91onk4UW3BUoxdDjvZbrVGYGVE9JtsxgjGo7w=
+knative.dev/kn-plugin-source-kafka v0.18.0 h1:qIDptZ/sIhWvFOg00BmyulD/+E9YdDX3GUrqiDb4KMo=
+knative.dev/kn-plugin-source-kafka v0.18.0/go.mod h1:1ERx7q91onk4UW3BUoxdDjvZbrVGYGVE9JtsxgjGo7w=
 knative.dev/networking v0.0.0-20200812200006-4d518e76538a/go.mod h1:ZewGJAElO4qPOeZTKuLIO3NQNGAkqcQVu64gHOSiPPg=
 knative.dev/networking v0.0.0-20200831172815-5f2e0ad6215f/go.mod h1:lt/ZAGq2ig/5jbJuHtJ41CibqWAIuBCRVCN29bvvSKQ=
 knative.dev/networking v0.0.0-20200922180040-a71b40c69b15 h1:UhUyfzy5VTEdkWXlkJAKLDPkPK9MKNpENfn17rlYtcs=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1113,7 +1113,7 @@ knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1
 knative.dev/eventing-contrib/kafka/source/pkg/client/clientset/versioned/scheme
 knative.dev/eventing-contrib/kafka/source/pkg/client/clientset/versioned/typed/sources/v1alpha1
 knative.dev/eventing-contrib/kafka/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake
-# knative.dev/kn-plugin-source-kafka v0.0.0-20201203183209-e1f755efaca3
+# knative.dev/kn-plugin-source-kafka v0.18.0
 ## explicit
 knative.dev/kn-plugin-source-kafka/pkg/client
 knative.dev/kn-plugin-source-kafka/pkg/factories


### PR DESCRIPTION
There're no vendor changes as v0.18.0 is equal to master.

/cc @navidshaikh 