### PR TITLE
Pass revision to git-clone task for Tekton tests

### DIFF
--- a/test/resources/tekton/kn-pipeline.yaml
+++ b/test/resources/tekton/kn-pipeline.yaml
@@ -40,6 +40,8 @@ spec:
     params:
     - name: url
       value: "https://github.com/knative/client"
+    - name: revision
+      value: "main"
   - name: buildah-build
     taskRef:
       name: buildah


### PR DESCRIPTION
Upstream PR is here: https://github.com/knative/client/pull/1270 . It contains the details about this change.