### PR TITLE
[release-v0.21.0] Use Serverless release branch in CI setup

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -12,8 +12,7 @@ failed=0
 # Run unit tests
  (( !failed )) && run_unit_tests || failed=1
 # Serverless operator setup & tests
-# TODO: change branch to "release-1.14" when available
-(( !failed )) && install_serverless_operator_branch "main" || failed=1
+(( !failed )) && install_serverless_operator_branch "release-1.15" || failed=1
 (( !failed )) && run_client_e2e_tests serving || failed=1
 (( !failed )) && run_client_e2e_tests eventing || failed=1
 


### PR DESCRIPTION
This PR is locking the Serverless version to the branch `release-1.15` for any future updates to be made to our `release-v0.21.0`.