### PR TITLE
[release-v1.0.0][SRVCLI-345] Cherrypick: change display versions (#1601)

### DIFF
--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -19,6 +19,7 @@ function build_flags() {
   rev="$(git rev-parse --short HEAD)"
   local pkg="knative.dev/client/pkg/kn/commands/version"
   local version="${TAG:-}"
+  local major_minor="$(echo "${version}" | cut -f1-2 -d. -n)"
   # Use vYYYYMMDD-local-<hash> for the version string, if not passed.
   if [[ -z "${version}" ]]; then
     # Get the commit, excluding any tags but keeping the "dirty" flag
@@ -27,13 +28,21 @@ function build_flags() {
     [[ -n "${commit}" ]] || abort "error getting the current commit"
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
-  # Extract Eventing and Serving versions from go.mod
+  # For Eventing and Serving versionings,
+  # major and minor versions are the same as client version
+  # patch version is from each technical version
+  technical_version_serving=$(grep "knative.dev/serving " "${base}/go.mod" \
+    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
+  technical_version_eventing=$(grep "knative.dev/eventing " "${base}/go.mod" \
+    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
   local version_serving version_eventing
-  version_serving=$(grep "knative.dev/serving " "${base}/go.mod" \
-    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
-  version_eventing=$(grep "knative.dev/eventing " "${base}/go.mod" \
-    | sed -s 's/.* \(v.[\.0-9]*\).*/\1/')
-
+  if [[ -n "${major_minor}" ]]; then
+    version_serving=${major_minor}.$(echo ${technical_version_serving} |cut -f3 -d.)
+    version_eventing=${major_minor}.$(echo ${technical_version_eventing} |cut -f3 -d.)
+  else
+    version_serving="${technical_version_serving}"
+    version_eventing="${technical_version_eventing}"
+  fi
   echo "-X '${pkg}.BuildDate=${now}' \
   -X ${pkg}.Version=${version} \
   -X ${pkg}.GitRevision=${rev} \


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVCLI-345

After the fix:
```
➜  client git:(release-v1.0.0) TAG="v1.0.0" ./hack/build.sh -f
🚧 Compile
➜  client git:(release-v1.0.0) kn version
Version:      v1.0.0
Build Date:   2022-03-03 12:26:07
Git Revision: 7b3796fa
Supported APIs:
* Serving
  - serving.knative.dev/v1 (knative-serving v1.0.1)
* Eventing
  - sources.knative.dev/v1 (knative-eventing v1.0.2)
  - eventing.knative.dev/v1 (knative-eventing v1.0.2)
```


/cc @mvinkler 
/cc @Kaustubh-pande 