### PR TITLE
Add test-e2e-image to supersede build-image

### DIFF
--- a/openshift/ci-operator/test-e2e-image/Dockerfile
+++ b/openshift/ci-operator/test-e2e-image/Dockerfile
@@ -1,0 +1,12 @@
+FROM src
+
+# Serverless operator tooling dependencies
+RUN yum install -y httpd-tools
+RUN wget -q https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
+
+# oc binary is injected by test steps to /cli dir + mask it as kubectl
+RUN ln -s /cli/oc /usr/bin/kubectl
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
This change is part of CI config refactoring, being done in https://github.com/openshift/release/pull/30988/files#diff-47d197ac7465707cb9e0cf4a8765ae460ec2596d37bd46fd8f8c2e42bd16ad88R60-R68.

Effectively this dockerfile covers `docker_literal` from the PR above. Once this one is merged I'll test it in my openshift/release PR. 


/cc @rhuss @matzew @pierDipi 